### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the repository setup helper during environment provisioning
+cd "$(dirname "$0")/.."
+
+./scripts/setup.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # study-go
+
+This repository contains a small sample application built with [Fiber](https://github.com/gofiber/fiber). The `scripts/setup.sh` helper installs Go and downloads the module dependencies. For Codex environments, `.codex/setup.sh` automatically runs this helper during provisioning so that dependencies are available before the network is disabled.
+
+## Setup
+
+Run the setup script from the repository root:
+
+```bash
+./scripts/setup.sh
+```
+
+Then build and run the app:
+
+```bash
+go run ./...
+```
+
+Run tests with:
+
+```bash
+go test ./...
+```
+
+## Codex environment
+
+This repository provides `.codex/setup.sh`. When using Codex, configure this as
+your environment's setup script so dependencies are installed automatically.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GO_VERSION=1.24.1
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "Installing Go ${GO_VERSION}..."
+    wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
+    sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+    rm go${GO_VERSION}.linux-amd64.tar.gz
+    export PATH=$PATH:/usr/local/go/bin
+fi
+
+if [ ! -f go.mod ]; then
+    echo "go.mod not found in $(pwd). Run this script from the repository root."
+    exit 1
+fi
+
+# Download module dependencies
+if command -v go >/dev/null 2>&1; then
+    echo "Downloading Go module dependencies..."
+    go mod download
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` so Codex can provision Go dependencies automatically
- document using the new setup script in README

## Testing
- `go test ./...` *(fails: `proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host`)*